### PR TITLE
Add simple client example

### DIFF
--- a/examples/client/simple-client.go
+++ b/examples/client/simple-client.go
@@ -1,0 +1,113 @@
+// Copyright 2019 go-sccp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// Command client sends given payload on top of SCCP UDT message.
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ishidawataru/sctp"
+	m3params "github.com/wmnsk/go-m3ua/messages/params"
+
+	"github.com/wmnsk/go-sccp"
+	"github.com/wmnsk/go-sccp/params"
+
+	"github.com/wmnsk/go-m3ua"
+)
+
+func main() {
+	var (
+		addr  = flag.String("aadr", "127.0.0.1:2905", "Remote IP and Port to connect to.")
+		data  = flag.String("data", "deadbeef", "Payload to send on UDT in hex format.")
+		hbInt = flag.Duration("hb-interval", 0, "Interval for M3UA BEAT. Put 0 to disable")
+	)
+	flag.Parse()
+
+	// setup data to send
+	payload, err := hex.DecodeString(*data)
+	if err != nil {
+		log.Fatalf("Failed to decode hex string: %s", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT)
+
+	// create *Config to be used in M3UA connection
+	m3config := m3ua.NewConfig(
+		0x11111111,              // OriginatingPointCode
+		0x22222222,              // DestinationPointCode
+		m3params.ServiceIndSCCP, // ServiceIndicator
+		0,                       // NetworkIndicator
+		0,                       // MessagePriority
+		1,                       // SignalingLinkSelection
+	)
+	m3config. // set parameters to use
+			EnableHeartbeat(*hbInt, 10*time.Second).
+			SetAspIdentifier(1).
+			SetTrafficModeType(m3params.TrafficModeLoadshare).
+			SetNetworkAppearance(0).
+			SetRoutingContexts(1, 2)
+
+	// setup SCTP peer on the specified IPs and Port.
+	raddr, err := sctp.ResolveSCTPAddr("sctp", *addr)
+	if err != nil {
+		log.Fatalf("Failed to resolve SCTP address: %s", err)
+	}
+
+	// setup underlying SCTP/M3UA connection first
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m3conn, err := m3ua.Dial(ctx, "m3ua", nil, raddr, m3config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create UDT message with CdPA, CgPA and payload
+	udt, err := sccp.NewUDT(
+		1,    // Protocol Class
+		true, // Message handling
+		params.NewPartyAddress( // CalledPartyAddress: 1234567890123456
+			0x12, 0, 6, 0x00, // Indicator, SPC, SSN, TT
+			0x01, 0x01, 0x04, // NP, ES, NAI
+			[]byte{0x21, 0x43, 0x65, 0x87, 0x09, 0x21, 0x43, 0x65},
+		),
+		params.NewPartyAddress( // CallingPartyAddress: 9876543210
+			0x12, 0, 7, 0x00, // Indicator, SPC, SSN, TT
+			0x01, 0x02, 0x04, // NP, ES, NAI
+			[]byte{0x89, 0x67, 0x45, 0x23, 0x01},
+		),
+		payload, // payload
+	).MarshalBinary()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// send once
+	if _, err := m3conn.Write(udt); err != nil {
+		log.Fatal(err)
+	}
+
+	// send once in 3 seconds
+	for {
+		ticker := time.NewTicker(3 * time.Second)
+		select {
+		case sig := <-sigCh:
+			log.Printf("Got signal: %v, exitting...", sig)
+			ticker.Stop()
+			os.Exit(1)
+		case <-ticker.C:
+			if _, err := m3conn.Write(udt); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add a simple SCCP client example which sends given payload on top of UDT message.

```
Signalling Connection Control Part
    Message Type: Unitdata (0x09)
    .... 0001 = Class: 0x1
    1000 .... = Message handling: Return message on error (0x8)
    Pointer to first Mandatory Variable parameter: 3
    Pointer to second Mandatory Variable parameter: 16
    Pointer to third Mandatory Variable parameter: 26
    Called Party address (13 bytes)
        Address Indicator
            0... .... = Reserved for national use: 0x0
            .0.. .... = Routing Indicator: Route on GT (0x0)
            ..01 00.. = Global Title Indicator: Translation Type, Numbering Plan, Encoding Scheme, and Nature of Address Indicator included (0x4)
            .... ..1. = SubSystem Number Indicator: SSN present (0x1)
            .... ...0 = Point Code Indicator: Point Code not present (0x0)
        SubSystem Number: HLR (Home Location Register) (6)
        [Linked to TCAP, TCAP SSN linked to GSM_MAP]
        Global Title 0x4 (11 bytes)
            Translation Type: 0x00
            0001 .... = Numbering Plan: ISDN/telephony (0x1)
            .... 0001 = Encoding Scheme: BCD, odd number of digits (0x1)
            .000 0100 = Nature of Address Indicator: International number (0x04)
            Called Party Digits: 123456789012345
                Called or Calling GT Digits: 123456789012345
                Number of Called Party Digits: 15
                Country Code: Americas (1)
    Calling Party address (10 bytes)
        Address Indicator
            0... .... = Reserved for national use: 0x0
            .0.. .... = Routing Indicator: Route on GT (0x0)
            ..01 00.. = Global Title Indicator: Translation Type, Numbering Plan, Encoding Scheme, and Nature of Address Indicator included (0x4)
            .... ..1. = SubSystem Number Indicator: SSN present (0x1)
            .... ...0 = Point Code Indicator: Point Code not present (0x0)
        SubSystem Number: VLR (Visitor Location Register) (7)
        [Linked to TCAP, TCAP SSN linked to GSM_MAP]
        Global Title 0x4 (8 bytes)
            Translation Type: 0x00
            0001 .... = Numbering Plan: ISDN/telephony (0x1)
            .... 0010 = Encoding Scheme: BCD, even number of digits (0x2)
            .000 0100 = Nature of Address Indicator: International number (0x04)
            Calling Party Digits: 9876543210
                Called or Calling GT Digits: 9876543210
                Number of Calling Party Digits: 10
                Country Code: Iran (Islamic Republic of) (98)
```