### PR TITLE
PartyAddress can be two bytes (Route on SSN without a PC)

### DIFF
--- a/params/party-address.go
+++ b/params/party-address.go
@@ -105,7 +105,7 @@ func ParsePartyAddress(b []byte) (*PartyAddress, error) {
 
 // UnmarshalBinary sets the values retrieved from byte sequence in a SCCP common header.
 func (p *PartyAddress) UnmarshalBinary(b []byte) error {
-	if len(b) < 3 {
+	if len(b) < 2 {
 		return io.ErrUnexpectedEOF
 	}
 	p.Length = b[0]
@@ -126,6 +126,9 @@ func (p *PartyAddress) UnmarshalBinary(b []byte) error {
 	if p.HasSSN() {
 		p.SubsystemNumber = b[offset]
 		offset++
+	}
+
+	if p.GTI() != 0 {
 		if offset >= len(b) {
 			return io.ErrUnexpectedEOF
 		}

--- a/sccp_test.go
+++ b/sccp_test.go
@@ -69,6 +69,35 @@ var testcases = []struct {
 			return v, nil
 		},
 	},
+	{
+		description: "UDT-2Bytes-PartyAddress",
+		structured: sccp.NewUDT(
+			1,    // Protocol Class
+			true, // Message handling
+			params.NewPartyAddress( // CalledPartyAddress: 1234567890123456
+				0x42, 0, 6, 0x00, // Indicator, SPC, SSN, TT
+				0x00, 0x00, 0x00, // NP, ES, NAI
+				[]byte{}, // GlobalTitleInformation
+			),
+			params.NewPartyAddress( // CalledPartyAddress: 1234567890123456
+				0x42, 0, 7, 0x00, // Indicator, SPC, SSN, TT
+				0x00, 0x00, 0x00, // NP, ES, NAI
+				[]byte{}, // GlobalTitleInformation
+			),
+			[]byte{},
+		),
+		serialized: []byte{
+			0x09, 0x81, 0x03, 0x05, 0x07, 0x02, 0x42, 0x06, 0x02, 0x42, 0x07, 0x00,
+		},
+		decodeFunc: func(b []byte) (serializable, error) {
+			v, err := sccp.ParseUDT(b)
+			if err != nil {
+				return nil, err
+			}
+
+			return v, nil
+		},
+	},
 }
 
 func TestMessages(t *testing.T) {


### PR DESCRIPTION
Hi,

Here is a PR to fix the parsing of a PartyAddress using Route on SSN without a PC.

This PR adds a test case as well.

Example of message:
![image](https://github.com/wmnsk/go-sccp/assets/8758184/fe6c736e-09c9-4ba9-8d5e-7b6c72d00b0b)

Thanks and cheers!
Valentin
