### PR TITLE
Add support for SCCP Management Message encoding/decoding

### DIFF
--- a/sccp_test.go
+++ b/sccp_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding"
 	"io"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/pascaldekloe/goe/verify"
@@ -98,6 +99,32 @@ var testcases = []struct {
 			return v, nil
 		},
 	},
+	{
+		description: "SCMG SSA",
+		structured:  sccp.NewSCMG(sccp.SCMGTypeSSA, 9, 405, 0, 0),
+		serialized:  []byte{0x1, 0x09, 0x95, 0x01, 0x00},
+		decodeFunc: func(b []byte) (serializable, error) {
+			v, err := sccp.ParseSCMG(b)
+			if err != nil {
+				return nil, err
+			}
+
+			return v, nil
+		},
+	},
+	{
+		description: "SCMG SSC",
+		structured:  sccp.NewSCMG(sccp.SCMGTypeSSC, 9, 405, 0, 4),
+		serialized:  []byte{0x6, 0x09, 0x95, 0x01, 0x00, 0x04},
+		decodeFunc: func(b []byte) (serializable, error) {
+			v, err := sccp.ParseSCMG(b)
+			if err != nil {
+				return nil, err
+			}
+
+			return v, nil
+		},
+	},
 }
 
 func TestMessages(t *testing.T) {
@@ -139,6 +166,9 @@ func TestMessages(t *testing.T) {
 				if _, ok := c.structured.(*sccp.Header); ok {
 					return
 				}
+				if _, ok := c.structured.(*sccp.SCMG); ok {
+					return
+				}
 
 				decoded, err := sccp.ParseMessage(c.serialized)
 				if err != nil {
@@ -158,7 +188,7 @@ func TestMessages(t *testing.T) {
 
 func TestPartialStructuredMessages(t *testing.T) {
 	for _, c := range testcases {
-		if c.description == "Header" {
+		if c.description == "Header" || strings.Contains(c.description, "SCMG") {
 			// TODO: consider removing Header struct as it's almost useless.
 			continue
 		}

--- a/scmg.go
+++ b/scmg.go
@@ -1,0 +1,143 @@
+// Copyright 2019-2024 go-sccp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package sccp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// SCMGType is type of SCMG message.
+type SCMGType uint8
+
+// Table 23/Q.713
+const (
+	_ SCMGType = iota
+	SCMGTypeSSA
+	SCMGTypeSSP
+	SCMGTypeSST
+	SCMGTypeSOR
+	SCMGTypeSOG
+	SCMGTypeSSC
+)
+
+// SCMG represents a SCCP Management message (SCMG).
+// Chapter 5.3/Q.713
+type SCMG struct {
+	Type                           SCMGType
+	AffectedSSN                    uint8
+	AffectedPC                     uint16
+	SubsystemMultiplicityIndicator uint8
+	SCCPCongestionLevel            uint8
+}
+
+// NewSCMG creates a new SCMG.
+func NewSCMG(typ SCMGType, affectedSSN uint8, affectedPC uint16, subsystemMultiplicityIndicator uint8, sccpCongestionLevel uint8) *SCMG {
+	s := &SCMG{
+		Type:                           typ,
+		AffectedSSN:                    affectedSSN,
+		AffectedPC:                     affectedPC,
+		SubsystemMultiplicityIndicator: subsystemMultiplicityIndicator,
+		SCCPCongestionLevel:            sccpCongestionLevel,
+	}
+
+	return s
+}
+
+// MarshalBinary returns the byte sequence generated from a SCMG instance.
+func (s *SCMG) MarshalBinary() ([]byte, error) {
+	b := make([]byte, s.MarshalLen())
+	if err := s.MarshalTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (s *SCMG) MarshalTo(b []byte) error {
+	l := len(b)
+
+	if l < s.MarshalLen() {
+		return io.ErrUnexpectedEOF
+	}
+
+	b[0] = uint8(s.Type)
+	b[1] = s.AffectedSSN
+	binary.LittleEndian.PutUint16(b[2:4], s.AffectedPC)
+	b[4] = s.SubsystemMultiplicityIndicator
+	if s.Type == SCMGTypeSSC {
+		b[5] = s.SCCPCongestionLevel
+	}
+
+	return nil
+}
+
+// ParseSCMG decodes given byte sequence as a SCMG.
+func ParseSCMG(b []byte) (*SCMG, error) {
+	s := &SCMG{}
+	if err := s.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// UnmarshalBinary sets the values retrieved from byte sequence in a SCMG.
+func (s *SCMG) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l < 5 {
+		return io.ErrUnexpectedEOF
+	}
+
+	s.Type = SCMGType(b[0])
+	s.AffectedSSN = b[1]
+	s.AffectedPC = binary.LittleEndian.Uint16(b[2:4])
+	s.SubsystemMultiplicityIndicator = b[4]
+
+	if s.Type == SCMGTypeSSC {
+		if l < 6 {
+			return io.ErrUnexpectedEOF
+		}
+		s.SCCPCongestionLevel = b[5]
+	}
+
+	return nil
+}
+
+// MarshalLen returns the serial length.
+func (s *SCMG) MarshalLen() int {
+	// Table 24/Q.713 – SCMG messages
+	l := 5
+
+	// Table 25/Q.713 – SSC
+	if s.Type == SCMGTypeSSC {
+		l += 1
+	}
+
+	return l
+}
+
+// String returns the SCMG values in human readable format.
+func (s *SCMG) String() string {
+	return fmt.Sprintf("{Type: %d, Affected SSN: %v, Affected PC: %v, Subsystem Multiplicity Indicator: %d, SCCP Congestion Level: %d}",
+		s.Type,
+		s.AffectedSSN,
+		s.AffectedPC,
+		s.SubsystemMultiplicityIndicator,
+		s.SCCPCongestionLevel,
+	)
+}
+
+// MessageType returns the Message Type in int.
+func (s *SCMG) MessageType() SCMGType {
+	return s.Type
+}
+
+// MessageTypeName returns the Message Type in string.
+func (s *SCMG) MessageTypeName() string {
+	return "SCMG"
+}


### PR DESCRIPTION
Add support for SCCP Management Message encoding/decoding

![image](https://github.com/wmnsk/go-sccp/assets/8758184/109592d8-1221-48a2-a94a-c7a7d2347ac0)

Spec is [ITU Q.713](https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-Q.713-200103-I!!PDF-E&type=items)

FYI: I'm currently building a PoC SIGTRAN stack with a sample 2G/3G NF on top of your libraries, I'll release it if I go far enough.

Thanks as usual :-)