### PR TITLE
fix: 3.4.2.1 Signaling Point Code at the SCCP layer should encoded/decoded in Little Endian

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -504,7 +504,7 @@ func (p *PartyAddress) read(b []byte) (int, error) {
 		if end >= len(b) {
 			return n, io.ErrUnexpectedEOF
 		}
-		p.SignalingPointCode = binary.BigEndian.Uint16(b[n:end])
+		p.SignalingPointCode = binary.LittleEndian.Uint16(b[n:end])
 		n = end
 	}
 
@@ -563,7 +563,7 @@ func (p *PartyAddress) write(b []byte) (int, error) {
 
 	var n = 2
 	if p.HasPC() {
-		binary.BigEndian.PutUint16(b[n:n+2], p.SignalingPointCode)
+		binary.LittleEndian.PutUint16(b[n:n+2], p.SignalingPointCode)
 		n += 2
 	}
 


### PR DESCRIPTION
Hi @wmnsk,

I hope you have been doing well!

Here is a little fix, go-sccp was incorrectly marshaling/unmarshaling SPC at the SCCP Layer in Big Endian instead of Little Endian. Here is an excerpt from Q.713:
![image](https://github.com/user-attachments/assets/65439048-ed12-40a2-ad47-9f062e0b7a7f)

Thanks and cheers,
Valentin